### PR TITLE
Documentation and ability to run analysis N number of times

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ __ifds-solver__ | "ra" or "heros"
 __static-analysis-lib__ | "soot" (OPAL currently not supported)
 __taint-analysis__ | "fw", "bidi", "gen", or "seq"
 __num-threads__ | number of threads to use for the IFDS solver. The number of threads used by SOOT is not affected by this number.
-__path-to-jre__ | Path to JRE folder
+__path-to-jre__ | Path to JRE folder. The easiest way to get this path is to run the command `/usr/libexec/java_home` on Mac OS X and append _'/jre'_
 
 Taint analysis explanation:
 - seq is the forwards IFDS algorithm on the Class.forName experimental setup in FlowTwist
@@ -36,6 +36,20 @@ Currently the supported taint analyses are:
 - heros soot gen
 
 These arguments and which analysis is run is controlled by `src/main/java/flow/twist/mains/Starter.java` which is the main class of the project.
+
+### Output
+The output of running the experimental evaluation is 10 files with the following names:
+
+
+ifds-solver\_static-analysis-lib\_taint-analysis\_num-threads_n
+
+where n is between 0 and 9 and contains the output of running the experimental evaluation for
+iteration n. Since the taint analysis is run 10 times, 10 files are created.
+
+For example, if `run ra soot fw 8 ...` is run, 10 files named ra\_soot\_fw\_8\_0, ra\_soot\_fw\_8\_1, ...,
+ra\_soot\_fw\_8\_9 are created.
+
+__To be written:__ how to extract running times in CSV format.
 
 ## How to run tests
 Run all tests:
@@ -56,6 +70,17 @@ where
 - SimpleTestRANoOPAL is the RA IFDS solver
 - SimpleTestBiDiNoOPAL is the sequential bidirectional IFDS solver
 - SimpleTestBiDiRANoOPAL is the bidirectional RA IFDS solver
+
+## File structure
+The classes for each taint analysis can be found in `src/main/java/flow/twist/mains/*`
+
+The main class is `src/main/java/flow/twist/mains/Starter.java`
+
+The main analysis classes are `src/main/java/flow/twist/AbstractAnalysis.java` and `src/main/java/flow/twist/AbstractMainAnalysis.java`
+
+The Heros IFDS solver can be found in `src/main/java/heros/solver/IDESolver.java`
+
+The Reactive Async IFDS solver can be found in `src/main/scala/IFDS/RAIFDSSolver.scala`
 
 ### References
 [1] http://dl.acm.org/citation.cfm?id=199462

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Concurrent implementation of the IFDS [1] algorithm based on Reactive Async [2]
 ## How to run experimental evaluation
 ```
 > sbt
-> run ifds-solver static-analysis-lib taint-analysis num-threads path-to-jre
+> run ifds-solver static-analysis-lib taint-analysis num-threads N path-to-jre
 ```
 
 Argument | Options
@@ -18,7 +18,8 @@ __ifds-solver__ | "ra" or "heros"
 __static-analysis-lib__ | "soot" (OPAL currently not supported)
 __taint-analysis__ | "fw", "bidi", "gen", or "seq"
 __num-threads__ | number of threads to use for the IFDS solver. The number of threads used by SOOT is not affected by this number.
-__path-to-jre__ | Path to JRE folder. The easiest way to get this path is to run the command `/usr/libexec/java_home` on Mac OS X and append _'/jre'_
+__N__ | Number of iterations to run.
+__path-to-jre__ | Path to JRE folder. The easiest way to get this path is to run the command `/usr/libexec/java_home` on Mac OS X and append _'/jre'_.
 
 Taint analysis explanation:
 - seq is the forwards IFDS algorithm on the Class.forName experimental setup in FlowTwist
@@ -38,16 +39,15 @@ Currently the supported taint analyses are:
 These arguments and which analysis is run is controlled by `src/main/java/flow/twist/mains/Starter.java` which is the main class of the project.
 
 ### Output
-The output of running the experimental evaluation is 10 files with the following names:
+The output of running the experimental evaluation is N files with the following names:
 
 
 ifds-solver\_static-analysis-lib\_taint-analysis\_num-threads_n
 
-where n is between 0 and 9 and contains the output of running the experimental evaluation for
-iteration n. Since the taint analysis is run 10 times, 10 files are created.
+where n is between 0 and N and contains the output of running the experimental evaluation for
+iteration n. Since the taint analysis is run N times, N files are created.
 
-For example, if `run ra soot fw 8 ...` is run, 10 files named ra\_soot\_fw\_8\_0, ra\_soot\_fw\_8\_1, ...,
-ra\_soot\_fw\_8\_9 are created.
+For example, if `run ra soot fw 8 3 ...` is run, 3 files named ra\_soot\_fw\_8\_0, ra\_soot\_fw\_8\_1, ra\_soot\_fw\_8\_2 are created.
 
 __To be written:__ how to extract running times in CSV format.
 

--- a/src/main/java/flow/twist/AbstractAnalysis.java
+++ b/src/main/java/flow/twist/AbstractAnalysis.java
@@ -25,11 +25,11 @@ import util.Util;
 public abstract class AbstractAnalysis {
 
   public void execute() {
-    execute("#", "#", "#", -1);
+    execute("#", "#", "#", -1, 0);
   }
 
-	public void execute(String ifds, String sa_lib, String ta, int numThreads) {
-    for (int j=0; j<10; ++j) {
+	public void execute(String ifds, String sa_lib, String ta, int numThreads, int N) {
+    for (int j=0; j<N; ++j) {
       ArrayList<String> argList = createArgs();
       AnalysisReporting.setSootArgs(argList);
       registerAnalysisTransformer(numThreads);

--- a/src/main/java/flow/twist/mains/BiDiRA.java
+++ b/src/main/java/flow/twist/mains/BiDiRA.java
@@ -12,9 +12,8 @@ import flow.twist.transformer.path.MergeEqualSelectorStrategy;
 import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class BiDiRA {
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public BiDiRA(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
 			@Override
 			protected Set<Path> _executeAnalysis() {
         return null;
@@ -22,8 +21,8 @@ public class BiDiRA {
 			@Override
 			protected void executeAnalysis() {
 				SolverFactory.runBiDiRASolver(AnalysisConfigurationBuilder.i2oSimpleClassForNameDefaults().reporter(
-						new ConsoleReporter()), threads);
+						new ConsoleReporter()), numCores);
 			}
-		}.execute("ra", "soot", "bidi", threads);
+		}.execute("ra", "soot", "bidi", numCores, N);
 	}
 }

--- a/src/main/java/flow/twist/mains/ClassForNameBiDi.java
+++ b/src/main/java/flow/twist/mains/ClassForNameBiDi.java
@@ -14,18 +14,17 @@ import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class ClassForNameBiDi {
 
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public ClassForNameBiDi(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
       @Override
 			protected void executeAnalysis() {
 				SolverFactory.runBiDirectionSolver(AnalysisConfigurationBuilder.i2oSimpleClassForNameDefaults().reporter(
-						new ConsoleReporter()), threads);
+						new ConsoleReporter()), numCores);
       }
 			@Override
 			protected Set<Path> _executeAnalysis() {
         return null;
 			}
-		}.execute("heros", "soot", "bidi", threads);
+		}.execute("heros", "soot", "bidi", numCores, N);
 	}
 }

--- a/src/main/java/flow/twist/mains/ClassForNameForwardsFromStringParams.java
+++ b/src/main/java/flow/twist/mains/ClassForNameForwardsFromStringParams.java
@@ -13,9 +13,8 @@ import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class ClassForNameForwardsFromStringParams {
 
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public ClassForNameForwardsFromStringParams(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
 			@Override
 			protected Set<Path> _executeAnalysis() {
         return null;
@@ -23,8 +22,8 @@ public class ClassForNameForwardsFromStringParams {
 			@Override
 			protected void executeAnalysis() {
 				SolverFactory.runOneDirectionSolver(AnalysisConfigurationBuilder.forwardsFromStringParametersDefaults(false).reporter(
-						new ConsoleReporter()), threads);
+						new ConsoleReporter()), numCores);
 			}
-		}.execute("heros", "soot", "fw", threads);
+		}.execute("heros", "soot", "fw", numCores, N);
 	}
 }

--- a/src/main/java/flow/twist/mains/GenBiDiRA.java
+++ b/src/main/java/flow/twist/mains/GenBiDiRA.java
@@ -12,17 +12,16 @@ import flow.twist.transformer.path.MergeEqualSelectorStrategy;
 import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class GenBiDiRA {
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public GenBiDiRA(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
 			@Override
 			protected Set<Path> _executeAnalysis() {
         return null;
       }
 			@Override
 			protected void executeAnalysis() {
-				SolverFactory.runBiDiRASolver(AnalysisConfigurationBuilder.i2oGenericCallerSensitiveDefaults().reporter(new ConsoleReporter()), threads);
+				SolverFactory.runBiDiRASolver(AnalysisConfigurationBuilder.i2oGenericCallerSensitiveDefaults().reporter(new ConsoleReporter()), numCores);
 			}
-		}.execute("ra", "soot", "gen", threads);
+		}.execute("ra", "soot", "gen", numCores, N);
 	}
 }

--- a/src/main/java/flow/twist/mains/GenericCallerSensitiveBiDi.java
+++ b/src/main/java/flow/twist/mains/GenericCallerSensitiveBiDi.java
@@ -14,18 +14,17 @@ import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class GenericCallerSensitiveBiDi {
 
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public GenericCallerSensitiveBiDi(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
 			@Override
 			protected void executeAnalysis() {
 				SolverFactory.runBiDirectionSolver(AnalysisConfigurationBuilder.i2oGenericCallerSensitiveDefaults().reporter(
-              new ConsoleReporter()), threads);
+              new ConsoleReporter()), numCores);
 			}
 			@Override
 			protected Set<Path> _executeAnalysis() {
         return null;
 			}
-		}.execute("heros", "soot", "gen", threads);
+		}.execute("heros", "soot", "gen", numCores, N);
 	}
 }

--- a/src/main/java/flow/twist/mains/RA.java
+++ b/src/main/java/flow/twist/mains/RA.java
@@ -12,9 +12,8 @@ import flow.twist.transformer.path.MergeEqualSelectorStrategy;
 import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class RA {
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public RA(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
 			@Override
 			protected Set<Path> _executeAnalysis() {
         return null;
@@ -22,8 +21,8 @@ public class RA {
 			@Override
 			protected void executeAnalysis() {
 				SolverFactory.runRASolver(AnalysisConfigurationBuilder.forwardsFromStringParametersDefaults(false).reporter(
-						new ConsoleReporter()), threads);
+						new ConsoleReporter()), numCores);
 			}
-		}.execute("ra", "soot", "fw", threads);
-	}
+		}.execute("ra", "soot", "fw", numCores, N);
+  }
 }

--- a/src/main/java/flow/twist/mains/RASEQ.java
+++ b/src/main/java/flow/twist/mains/RASEQ.java
@@ -12,9 +12,8 @@ import flow.twist.transformer.path.MergeEqualSelectorStrategy;
 import flow.twist.transformer.path.PathBuilderResultTransformer;
 
 public class RASEQ {
-	public static void main(final String[] a) {
-    int threads = Integer.parseInt(a[0]);
-		new AbstractMainAnalysis(java.util.Arrays.copyOfRange(a, 1, a.length)) {
+  public RASEQ(int numCores, int N, String[] args) {
+		new AbstractMainAnalysis(args) {
       @Override
       protected Set<Path> _executeAnalysis() {
         return null;
@@ -22,8 +21,8 @@ public class RASEQ {
 			@Override
 			protected void executeAnalysis() {
 				SolverFactory.runRASEQSolver(AnalysisConfigurationBuilder.forwardsFromStringParametersDefaults(false).reporter(
-						new ConsoleReporter()), threads);
+						new ConsoleReporter()), numCores);
 			}
-		}.execute("ra", "soot", "seq", threads);
+		}.execute("ra", "soot", "seq", numCores, N);
 	}
 }

--- a/src/main/java/flow/twist/mains/Starter.java
+++ b/src/main/java/flow/twist/mains/Starter.java
@@ -6,24 +6,25 @@ class Starter {
   public static void main(String[] args) {
     List<String> argList = new ArrayList<String>(Arrays.asList(args));
     System.out.println(Arrays.toString(args));
-    String arg1 = argList.remove(0);
-    String arg2 = argList.remove(0);
-    String arg3 = argList.remove(0);
-    args = new String[args.length-3];
+    String ifdsSolver = argList.remove(0);
+    String saLib = argList.remove(0);
+    String taintAnalysis = argList.remove(0);
+    int numCores = Integer.parseInt(argList.remove(0));
+    int N = Integer.parseInt(argList.remove(0));
+    args = new String[args.length-5];
     argList.toArray(args);
-    System.out.println(Arrays.toString(args));
-    if (arg1.equals("heros") && arg2.equals("soot")) {
+    if (ifdsSolver.equals("heros") && saLib.equals("soot")) {
 
-      if (arg3.equals("fw")) ClassForNameForwardsFromStringParams.main(args);
-      else if (arg3.equals("bidi")) ClassForNameBiDi.main(args);
-      else if (arg3.equals("gen")) GenericCallerSensitiveBiDi.main(args);
+      if (taintAnalysis.equals("fw")) new ClassForNameForwardsFromStringParams(numCores, N, args);
+      else if (taintAnalysis.equals("bidi")) new ClassForNameBiDi(numCores, N, args);
+      else if (taintAnalysis.equals("gen")) new GenericCallerSensitiveBiDi(numCores, N, args);
 
-    } else if (arg1.equals("ra") && arg2.equals("soot")) {
+    } else if (ifdsSolver.equals("ra") && saLib.equals("soot")) {
 
-      if (arg3.equals("fw")) RA.main(args);
-      else if (arg3.equals("bidi")) BiDiRA.main(args);
-      else if (arg3.equals("gen")) GenBiDiRA.main(args);
-      else if (arg3.equals("seq")) RASEQ.main(args);
+      if (taintAnalysis.equals("fw")) new RA(numCores, N, args);
+      else if (taintAnalysis.equals("bidi")) new BiDiRA(numCores, N, args);
+      else if (taintAnalysis.equals("gen")) new GenBiDiRA(numCores, N, args);
+      else if (taintAnalysis.equals("seq")) new RASEQ(numCores, N, args);
 
     } else {
       throw new IllegalArgumentException();


### PR DESCRIPTION
Two changes:

1. **Documentation.** Updated documentation, explained what the output of running the experimental evaluation is. Added terminal command for getting path to JRE.
2. **Extra argument to experimental evaluation.** An extra argument is required when running the experimental evaluation. It specifies how many times the analysis should be run. Before this was just a fixed number (10) but this is now specified by the user. This is reflected in the README. Each analysis no longer has its own main method but is instead run by calling the constructor for that analysis class which takes three arguments (numCores, N, args).